### PR TITLE
Small visual fixes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -121,6 +121,7 @@
           width: 300px;
           height: auto;
         }
+        img { max-width: 100%; }
         h1,h2,h3 { clear: both;}
 
         .nav-pills, .dropdown-menu
@@ -135,6 +136,11 @@
         {
           background-color: #c6002a;
           color: #00ACEB;
+        }
+        .nav{
+          position: sticky;
+          top: 0;
+          z-index: 5;
         }
 
         .tip


### PR DESCRIPTION
Made the navigation bar sticky.
Added an extra rule for img-tags, because on small screens the images don't scale. (So you need to scroll to see the whole picture)